### PR TITLE
Fix the image URL #227

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,10 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@masa_kudamatsu" />
 
-    <meta property="og:image" content="%PUBLIC_URL%/logo2x.png" />
+    <meta
+      property="og:image"
+      content="https://line-height-picker.app/logo2x.png"
+    />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:height" content="501" />
     <meta property="og:image:width" content="1210" />


### PR DESCRIPTION
Facebook Sharing Debugger complains that "/logo2x.png was not a valid URL".